### PR TITLE
Correct 2018 to 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OPLSS 2019
 
 This repository collects notes and resources associated with the 
-[2018 Oregon Programming Languages Summer School](https://www.cs.uoregon.edu/research/summerschool/summer19)
+[2019 Oregon Programming Languages Summer School](https://www.cs.uoregon.edu/research/summerschool/summer19)
 
 https://www.cs.uoregon.edu/research/summerschool/summer19/topics.php
 


### PR DESCRIPTION
I corrected a 2018 reference to 2019